### PR TITLE
Fixes if condition bug in the Fullcalendar Module

### DIFF
--- a/src/Resources/contao/modules/ModuleFullcalendar.php
+++ b/src/Resources/contao/modules/ModuleFullcalendar.php
@@ -318,7 +318,7 @@ class ModuleFullcalendar extends EventsExt
 
                     // We take the "show from" time or the "event start" time to check the display duration limit
                     $displayStart = ($event['start']) ? $event['start'] : $event['startTime'];
-                    if (strlen($this->displayDuration) > 0) {
+                    if ($this->displayDuration > 0) {
                         $displayStop = strtotime($this->displayDuration, $displayStart);
                         if ($displayStop < $currTime) {
                             continue;

--- a/src/Resources/contao/modules/ModuleFullcalendar.php
+++ b/src/Resources/contao/modules/ModuleFullcalendar.php
@@ -318,9 +318,9 @@ class ModuleFullcalendar extends EventsExt
 
                     // We take the "show from" time or the "event start" time to check the display duration limit
                     $displayStart = ($event['start']) ? $event['start'] : $event['startTime'];
-                    if ($this->displayDuration > 0) {
+                    if (strlen($this->displayDuration) > 0) {
                         $displayStop = strtotime($this->displayDuration, $displayStart);
-                        if ($displayStop < $currTime) {
+                        if ($displayStop !== false && $displayStop < $currTime) {
                             continue;
                         }
                     }


### PR DESCRIPTION
There is a bug in the fullcalendar module fetchEvents() function. The function checks if the displayDuration value length is bigger than 0. In fact that this property isn't configurable in this module palettes, this will result in no event results in the frontend.