### PR TITLE
Add support for image sizes declared in config.yml

### DIFF
--- a/src/Resources/contao/modules/ModuleEventReader.php
+++ b/src/Resources/contao/modules/ModuleEventReader.php
@@ -493,7 +493,7 @@ class ModuleEventReader extends EventsExt
                 if ($this->imgSize != '') {
                     $size = deserialize($this->imgSize);
 
-                    if ($size[0] > 0 || $size[1] > 0 || is_numeric($size[2])) {
+                    if ($size[0] > 0 || $size[1] > 0 || is_numeric($size[2]) || ($size[2][0] ?? null) === '_') {
                         $arrEvent['size'] = $this->imgSize;
                     }
                 }

--- a/src/Resources/contao/modules/ModuleEventlist.php
+++ b/src/Resources/contao/modules/ModuleEventlist.php
@@ -420,7 +420,7 @@ class ModuleEventlist extends EventsExt
         if ($this->imgSize != '') {
             $size = deserialize($this->imgSize);
 
-            if ($size[0] > 0 || $size[1] > 0 || is_numeric($size[2])) {
+            if ($size[0] > 0 || $size[1] > 0 || is_numeric($size[2]) || ($size[2][0] ?? null) === '_') {
                 $imgSize = $this->imgSize;
             }
         }


### PR DESCRIPTION
Bildgrössen welche im file /config/config.yml deklariert wurden, werden generiert.

Beispielcode für das Config:

```
contao:
  image:
    sizes:
      gallery_3:
        width: 420
        height: 280
        resizeMode: 'crop'
        densities: '1x,2x'
        zoom: 100
        css_class: 'image-size-gallery_3'
        lazy_loading: true
        formats:
          jpg: ['webp','jpg']
          png: ['webp','png']
          gif: ['webp','gif']

```

