### PR TITLE
fix irregular recurrences

### DIFF
--- a/src/Resources/contao/classes/EventsExt.php
+++ b/src/Resources/contao/classes/EventsExt.php
@@ -416,14 +416,14 @@ class EventsExt extends Events
 
                             // new start time
                             $strNewDate = $fixedDate['new_repeat'];
-                            $strNewTime = (strlen($fixedDate['new_start']) ? $fixedDate['new_start'] : $orgDateStart->time);
-                            $newDateStart = new Date(strtotime($strNewDate . ' ' . $strNewTime), \Config::get('datimFormat'));
+                            $strNewTime = (strlen($fixedDate['new_start']) ? date('H:i', $fixedDate['new_start']) : $orgDateStart->time);
+                            $newDateStart = new Date(strtotime(date("d.m.Y", $strNewDate) . ' ' . $strNewTime), \Config::get('datimFormat'));
                             $objEvents->startTime = $newDateStart->timestamp;
                             $dateNextStart = date('Ymd', $objEvents->startTime);
 
                             // new end time
-                            $strNewTime = (strlen($fixedDate['new_end']) ? $fixedDate['new_end'] : $orgDateEnd->time);
-                            $newDateEnd = new Date(trim($strNewDate . ' ' . $strNewTime), \Config::get('datimFormat'));
+                            $strNewTime = (strlen($fixedDate['new_end']) ? date('H:i', $fixedDate['new_end']) : $orgDateEnd->time);
+                            $newDateEnd = new Date(strtotime(date("d.m.Y", $strNewDate) . ' ' . $strNewTime), \Config::get('datimFormat'));
 
                             // use the multi-day span of the event
                             if ($orgDateSpan > 0) {

--- a/src/Resources/contao/dca/tl_calendar_events.php
+++ b/src/Resources/contao/dca/tl_calendar_events.php
@@ -680,11 +680,14 @@ class tl_calendar_events_ext extends \Backend
                     return false;
                 }
 
-                $new_fix_date = strtotime($fixedDate['new_repeat']);
+                //$new_fix_date = strtotime($fixedDate['new_repeat']);
+                $new_fix_date = $fixedDate['new_repeat'];
 
                 // Check if we have a new start time
-                $new_fix_start_time = strlen($fixedDate['new_start']) ? $fixedDate['new_start'] : date('H:i', $arrSet['startTime']);
-                $new_fix_end_time = strlen($fixedDate['new_end']) ? $fixedDate['new_end'] : date('H:i', $arrSet['endTime']);
+                //$new_fix_start_time = strlen($fixedDate['new_start']) ? $fixedDate['new_start'] : date('H:i', $arrSet['startTime']);
+                $new_fix_start_time = strlen($fixedDate['new_start']) ? date('H:i', $fixedDate['new_start']) : date('H:i', $arrSet['startTime']);
+                //$new_fix_end_time = strlen($fixedDate['new_end']) ? $fixedDate['new_end'] : date('H:i', $arrSet['endTime']);
+                $new_fix_end_time = strlen($fixedDate['new_end']) ? date('H:i', $fixedDate['new_end']) : date('H:i', $arrSet['endTime']);
 
                 $new_fix_start_date = strtotime(date("d.m.Y", $new_fix_date) . ' ' . date("H:i", strtotime($new_fix_start_time)));
                 $new_fix_end_date = strtotime(date("d.m.Y", $new_fix_date) . ' ' . date("H:i", strtotime($new_fix_end_time)));


### PR DESCRIPTION
Dieser PR behebt eine Exceptionbeim Anzeigen von unregelmäßigen Wiederholungen.
`Uncaught PHP Exception OutOfBoundsException: "Invalid date "1617746400 15:30""`

Das Array `repeatFixedDates` enthält die Datumswerte als Unix Timestamp. Diese wurden vermischt mit formatierten Datumswerte als String. Mit den Änderungen wird die Handhabung vereinheitlicht.

Ggf. müssen Events, welche diese Funktionalität nutzen neu abgespeichert werden.