### PR TITLE
Add fallback template

### DIFF
--- a/src/Resources/contao/modules/ModuleEventReader.php
+++ b/src/Resources/contao/modules/ModuleEventReader.php
@@ -332,7 +332,7 @@ class ModuleEventReader extends EventsExt
     }
 
     /** @var \FrontendTemplate|object $objTemplate */
-    $objTemplate = new \FrontendTemplate($this->cal_template);
+    $objTemplate = new \FrontendTemplate($this->cal_template ?: 'event_full');
     $objTemplate->setData($objEvent->row());
 
     $objTemplate->date = $strDate;

--- a/src/Resources/contao/modules/ModuleEventlist.php
+++ b/src/Resources/contao/modules/ModuleEventlist.php
@@ -436,7 +436,7 @@ class ModuleEventlist extends EventsExt
             }
 
             /** @var \FrontendTemplate|object $objTemplate */
-            $objTemplate = new \FrontendTemplate($this->cal_template);
+            $objTemplate = new \FrontendTemplate($this->cal_template ?: 'event_list');
             $objTemplate->setData($event);
 
             // Month header


### PR DESCRIPTION
When I started using your extension, I have discovered an issue.
I get an empty result in the frontend because I did not choose an explicit calendar-template in the module settings.

With this pull request, I am adding a fallback template, when generating the event output.
They are the same templates as used in the contao/calendar-bundle.