### PR TITLE
Check for false instead of null in ModuleEventRegistration

### DIFF
--- a/src/Resources/contao/modules/ModuleEventRegistration.php
+++ b/src/Resources/contao/modules/ModuleEventRegistration.php
@@ -115,7 +115,7 @@ class ModuleEventRegistration extends \Module
                 $arrTokens = array();
                 $objResult = CalendarLeadsModel::findByLeadEventMail($lead_id, $event_id, $email);
 
-                if ($objResult !== null) {
+                if ($objResult !== false) {
                     // zuerst den entsprechenden Datensatz updaten...
                     $published = $this->regtype;
                     $result = CalendarLeadsModel::updateByPid($objResult->pid, $published);


### PR DESCRIPTION
`CalendarLeadsModel::findByLeadEventMail` will return `false` here

https://github.com/kmielke/calendar-extended-bundle/blob/7364133ff0216bcc4172d9c37d7dd79a0fbb3ce4/src/Resources/contao/models/CalendarLeadsModel.php#L110-L113

thus `ModuleEventRegistration` needs to check for `false` instead of `null` (see [here](https://community.contao.org/de/showthread.php?67732-Fatal-error-Anmeldung-best%C3%A4tigen&p=547502&viewfull=1#post547502).

Fixes #29 