### PR TITLE
Fix #58 - Contao 4.13 Compatibility

### DIFF
--- a/src/Resources/contao/modules/ModuleEventReader.php
+++ b/src/Resources/contao/modules/ModuleEventReader.php
@@ -512,6 +512,19 @@ class ModuleEventReader extends EventsExt
       $this->addEnclosuresToTemplate($objTemplate, $objEvent->row());
     }
 
+    // schema.org information
+    if (method_exists(\Events::class, 'getSchemaOrgData')) {
+        $objTemplate->getSchemaOrgData = static function () use ($objTemplate, $event): array{
+            $jsonLd = \Events::getSchemaOrgData((new \CalendarEventsModel())->setRow($event));
+
+            if ($objTemplate->addImage && $objTemplate->figure){
+                $jsonLd['image'] = $objTemplate->figure->getSchemaOrgData();
+            }
+
+            return $jsonLd;
+        };
+    }
+
     $this->Template->event = $objTemplate->parse();
 
     // HOOK: comments extension required

--- a/src/Resources/contao/modules/ModuleEventlist.php
+++ b/src/Resources/contao/modules/ModuleEventlist.php
@@ -504,6 +504,20 @@ class ModuleEventlist extends EventsExt
                 $this->addEnclosuresToTemplate($objTemplate, $event);
             }
 
+
+			// schema.org information
+            if (method_exists(\Events::class, 'getSchemaOrgData')) {
+                $objTemplate->getSchemaOrgData = static function () use ($objTemplate, $event): array{
+                    $jsonLd = \Events::getSchemaOrgData((new \CalendarEventsModel())->setRow($event));
+
+                    if ($objTemplate->addImage && $objTemplate->figure){
+                        $jsonLd['image'] = $objTemplate->figure->getSchemaOrgData();
+                    }
+
+                    return $jsonLd;
+                };
+            }
+
             $strEvents .= $objTemplate->parse();
 
             ++$eventCount;


### PR DESCRIPTION
Fixes #58, making this extension compatible with Contao 4.13 by adding the required getSchemaOrgData function to $objTemplate in ModuleEventlist and ModuleEventReader.