### PR TITLE
Add missing calendar template variable

### DIFF
--- a/src/Resources/contao/modules/ModuleEventReader.php
+++ b/src/Resources/contao/modules/ModuleEventReader.php
@@ -344,6 +344,7 @@ class ModuleEventReader extends EventsExt
     $objTemplate->recurring = $recurring;
     $objTemplate->until = $until;
     $objTemplate->locationLabel = $GLOBALS['TL_LANG']['MSC']['location'];
+    $objTemplate->calendar = $objEvent->getRelated('pid');
     $objTemplate->details = '';
     $objTemplate->hasDetails = false;
     $objTemplate->hasTeaser = false;


### PR DESCRIPTION
This adds the missing `calendar` template variable, which was added 4 years ago in Contao 4.6 (see https://github.com/contao/contao/commit/2ce36713ebecd84b022acab9f3ceaa685b1a7966). This improves compatibility with other extensions such as https://github.com/inspiredminds/contao-event-registration