### PR TITLE
Make leads optional and suggest v1 to support user registraion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,13 @@
     "contao/core-bundle": "^4.4",
     "contao/calendar-bundle": "^4.4",
     "menatwork/contao-multicolumnwizard-bundle": "^3.4",
-    "terminal42/notification_center": "^1.5",
+    "terminal42/notification_center": "^1.5"
+  },
+  "require-dev": {
     "terminal42/contao-leads": "^1.4"
+  },
+  "suggest": {
+    "terminal42/contao-leads": "Supports user registration - but only compatible with leads in version 1!"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Since [terminal42/leads](https://github.com/terminal42/contao-leads) is available in version 3, the installation of leads v1 should not be mandatory.
Debugging the legacy code to support leads in v3 is too complex, so I would suggest v1 as optional!