### PR TITLE
Fix undefined array keys + variables

### DIFF
--- a/src/Resources/contao/classes/EventsExt.php
+++ b/src/Resources/contao/classes/EventsExt.php
@@ -242,8 +242,8 @@ class EventsExt extends Events
                             break;
                         }
 
-                        $arg = $arrRepeat['value'];
-                        $unit = $arrRepeat['unit'];
+                        $arg = $arrRepeat['value'] ?? null;
+                        $unit = $arrRepeat['unit'] ?? null;
 
                         $addmonth = true;
                         if ($objEvents->recurring) {
@@ -283,8 +283,10 @@ class EventsExt extends Events
                             }
                         }
 
+                        $oldDate = array();
+
                         // check if there is any exception
-                        if (is_array($arrEventSkipInfo[$objEvents->id])) {
+                        if (isset($arrEventSkipInfo[$objEvents->id]) && is_array($arrEventSkipInfo[$objEvents->id])) {
                             // modify the css class of the exceptions
                             $objEvents->cssClass = $masterCSSClass;
                             unset($objEvents->moveReason);
@@ -297,7 +299,7 @@ class EventsExt extends Events
                             // store old date values for later reset
                             $oldDate = array();
 
-                            if (is_array($arrEventSkipInfo[$objEvents->id][$findDate])) {
+                            if (isset($arrEventSkipInfo[$objEvents->id][$findDate]) && is_array($arrEventSkipInfo[$objEvents->id][$findDate])) {
                                 // $r = $searchDate;
                                 $r = $findDate;
                                 $action = $arrEventSkipInfo[$objEvents->id][$r]['action'];
@@ -349,7 +351,7 @@ class EventsExt extends Events
                         // Skip events outside the scope
                         if ($objEvents->endTime < $intStart || $objEvents->startTime > $intEnd) {
                             // in case of a move we have to reset the original date
-                            if ($oldDate) {
+                            if (!empty($oldDate)) {
                                 $objEvents->startTime = $oldDate['startTime'];
                                 $objEvents->endTime = $oldDate['endTime'];
                             }
@@ -390,7 +392,7 @@ class EventsExt extends Events
                         $objEvents->oldEndTime = null;
 
                         // in case of a move we have to reset the original date
-                        if ($oldDate) {
+                        if (!empty($oldDate)) {
                             $objEvents->startTime = $oldDate['startTime'];
                             $objEvents->endTime = $oldDate['endTime'];
                         }

--- a/src/Resources/contao/dca/tl_calendar_events.php
+++ b/src/Resources/contao/dca/tl_calendar_events.php
@@ -639,6 +639,7 @@ class tl_calendar_events_ext extends \Backend
             return;
         }
 
+        $arrDates = array();
         $maxCount = ($GLOBALS['TL_CONFIG']['tl_calendar_events']['maxRepeatExceptions']) ? $GLOBALS['TL_CONFIG']['tl_calendar_events']['maxRepeatExceptions'] : 365;
         $maxELCount = 250;
 
@@ -737,8 +738,8 @@ class tl_calendar_events_ext extends \Backend
         if ($dc->activeRecord->recurring) {
             $arrRange = deserialize($dc->activeRecord->repeatEach);
 
-            $arg = $arrRange['value'] * $dc->activeRecord->recurrences;
-            $unit = $arrRange['unit'];
+            $arg = isset($arrRange['value']) ? $arrRange['value'] * $dc->activeRecord->recurrences : 0;
+            $unit = $arrRange['unit'] ?? null;
 
             $strtotime = '+ ' . $arg . ' ' . $unit;
             $arrSet['repeatEnd'] = strtotime($strtotime, $arrSet['endTime']);
@@ -768,7 +769,7 @@ class tl_calendar_events_ext extends \Backend
             $end = $arrSet['repeatEnd'];
 
             while ($next <= $end) {
-                $timetoadd = '+ ' . $arrRange['value'] . ' ' . $unit;
+                $timetoadd = '+ ' . ($arrRange['value'] ?? null) . ' ' . $unit;
 
                 // Check if we are at the end
                 if (!strtotime($timetoadd, $next)) {
@@ -831,8 +832,8 @@ class tl_calendar_events_ext extends \Backend
         if ($dc->activeRecord->recurringExt) {
             $arrRange = deserialize($dc->activeRecord->repeatEachExt);
 
-            $arg = $arrRange['value'];
-            $unit = $arrRange['unit'];
+            $arg = isset($arrRange['value']) ? $arrRange['value'] : 0;
+            $unit = $arrRange['unit'] ?? null;
 
             // next month of the event
             $month = (int)date('n', $dc->activeRecord->startDate);

--- a/src/Resources/contao/dca/tl_module.php
+++ b/src/Resources/contao/dca/tl_module.php
@@ -406,7 +406,7 @@ class calendar_Ext extends \Backend
         $event_fields = [];
         foreach ($arr_fields as $k => $v) {
             if (strlen($GLOBALS['TL_LANG']['tl_calendar_events'][$k][0])) {
-                $label = (strlen($v['label'])) ? $v['label'] : $GLOBALS['TL_LANG']['tl_calendar_events'][$k][0];
+                $label = (!empty($v['label'])) ? $v['label'] : $GLOBALS['TL_LANG']['tl_calendar_events'][$k][0];
                 $event_fields[$k] = $label;
             }
         }

--- a/src/Resources/contao/modules/ModuleEventReader.php
+++ b/src/Resources/contao/modules/ModuleEventReader.php
@@ -252,7 +252,7 @@ class ModuleEventReader extends EventsExt
 
       if (is_array($arrRange) && isset($arrRange['unit']) && isset($arrRange['value'])) {
         $strKey = 'cal_' . $arrRange['unit'];
-        $recurring = sprintf($GLOBALS['TL_LANG']['MSC'][$strKey], $arrRange['value']);
+        $recurring = sprintf($GLOBALS['TL_LANG']['MSC'][$strKey] ?? null, $arrRange['value']);
 
         if ($objEvent->recurrences > 0) {
           $until = sprintf($GLOBALS['TL_LANG']['MSC']['cal_until'], \Date::parse($objPage->dateFormat, $objEvent->repeatEnd));


### PR DESCRIPTION
This PR fixes some php 8 warnings with undefined keys + variables